### PR TITLE
forest.toml: remove pointer to nonexistent directory

### DIFF
--- a/forest.toml
+++ b/forest.toml
@@ -1,4 +1,4 @@
 [forest]
 trees = ["trees"]
-assets = ["assets"]
+assets = []
 theme = "theme"


### PR DESCRIPTION
The current configuration points to an 'assets' directory that is not checked into git. At least some versions of Forester will error out when they hit this.

(If you do want to check an empty directory into git, I think you need to put some kind of dummy file in there unfortunately.)