### PR TITLE
Remove transclusion override

### DIFF
--- a/trees/index.tree
+++ b/trees/index.tree
@@ -1,7 +1,7 @@
 \title{Golden Forest for show all syntax}
 \author{jinser}
 
-\p{Written with reference to [jon's tree](https://git.sr.ht/~jonsterling/public-trees/).}
+\p{Written with reference to [Jon’s trees](https://git.sr.ht/~jonsterling/public-trees/).}
 
 \transclude{comment}
 \transclude{prim}

--- a/trees/scope.tree
+++ b/trees/scope.tree
@@ -11,7 +11,7 @@
 }
 
 \scope{
-  \put\transclude/title{foooo}
+  \put\transclude/toc{false}
   \transclude{jinser}
 }
 


### PR DESCRIPTION
A future release of Forester will remove support for overriding titles in transclusions. 